### PR TITLE
Feature/#create_nichespot_get_api

### DIFF
--- a/src/app/Http/Controllers/NicheSpotController.php
+++ b/src/app/Http/Controllers/NicheSpotController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\NicheSpotService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class NicheSpotController extends Controller
+{
+
+    /**
+     * @param NicheSpotService $nicheSpotService
+     */
+    public function __construct(protected NicheSpotService $nicheSpotService)
+    {
+    }
+
+    /**
+     * ニッチスポット一覧取得API
+     * 
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function index(Request $request) : JsonResponse
+    {
+        return $this->nicheSpotService->getNicheSpot($request);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+}

--- a/src/app/Models/NicheSpot.php
+++ b/src/app/Models/NicheSpot.php
@@ -40,6 +40,9 @@ class NicheSpot extends Model
         self::DELETED_AT,
     ];
 
+    // リクエスト用定数
+    const KEYWORD = 'keyword';
+
     // レスポンス用定数
     const NICHE_SPOTS = 'niche_spots';
     const NUMBER_OF_VISITS = 'number_of_visits';

--- a/src/app/Models/NicheSpot.php
+++ b/src/app/Models/NicheSpot.php
@@ -39,4 +39,15 @@ class NicheSpot extends Model
         self::UPDATED_AT,
         self::DELETED_AT,
     ];
+
+    // レスポンス用定数
+    const NICHE_SPOTS = 'niche_spots';
+    const NUMBER_OF_VISITS = 'number_of_visits';
+    const IS_VISITED = 'is_visited';
+    const STAMPS_COUNT = 'stamps_count';
+
+    public function stamps()
+    {
+        return $this->hasMany(Stamp::class, 'niche_spot_id', 'id');
+    }
 }

--- a/src/app/Providers/AppServiceProvider.php
+++ b/src/app/Providers/AppServiceProvider.php
@@ -23,5 +23,9 @@ class AppServiceProvider extends ServiceProvider
             \App\Repositories\User\UserRepositoryInterface::class,
             \App\Repositories\User\UserRepository::class,
         );
+        $this->app->bind(
+            \App\Repositories\NicheSpot\NicheSpotRepositoryInterface::class,
+            \App\Repositories\NicheSpot\NicheSpotRepository::class,
+        );
     }
 }

--- a/src/app/Repositories/NicheSpot/NicheSpotRepository.php
+++ b/src/app/Repositories/NicheSpot/NicheSpotRepository.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories\NicheSpot;
+
+use App\Models\NicheSpot;
+use App\Models\Stamp;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
+
+class NicheSpotRepository implements NicheSpotRepositoryInterface
+{
+
+    /**
+     * NicheSpotRepository コンストラクタ
+     * NicheSpot の依存性を注入する
+     * 
+     * @param NicheSpot $nicheSpot
+     */
+    public function __construct(protected NicheSpot $nicheSpot) {}
+
+    /**
+     * ニッチスポット一覧取得
+     * 
+     * @return Collection
+     */
+    public function getNicheSpot(int $userId): Collection
+    {
+        // NicheSpot を取得し、スタンプ数と is_visited を含めて返す
+        return NicheSpot::withCount('stamps') // スタンプの数を取得
+            ->get()
+            ->map(function ($nicheSpot) use ($userId) {
+                $nicheSpot->is_visited = $nicheSpot->stamps()->where('user_id', $userId)->exists();
+                return $nicheSpot;
+            });
+    }
+    
+}

--- a/src/app/Repositories/NicheSpot/NicheSpotRepository.php
+++ b/src/app/Repositories/NicheSpot/NicheSpotRepository.php
@@ -25,15 +25,22 @@ class NicheSpotRepository implements NicheSpotRepositoryInterface
      * 
      * @return Collection
      */
-    public function getNicheSpot(int $userId): Collection
+    public function getNicheSpot(int $userId, $keyword): Collection
     {
-        // NicheSpot を取得し、スタンプ数と is_visited を含めて返す
-        return NicheSpot::withCount('stamps') // スタンプの数を取得
-            ->get()
-            ->map(function ($nicheSpot) use ($userId) {
-                $nicheSpot->is_visited = $nicheSpot->stamps()->where('user_id', $userId)->exists();
-                return $nicheSpot;
+        $query = NicheSpot::withCount('stamps'); // スタンプの数をカウントする
+
+        // キーワードが指定されていた場合、name と address で検索を追加
+        if ($keyword) {
+            $query->where(function ($q) use ($keyword) {
+                $q->where('name', 'like', "%{$keyword}%")
+                    ->orWhere('address', 'like', "%{$keyword}%");
             });
+        }
+
+        // 結果を取得して、is_visited を追加
+        return $query->get()->map(function ($nicheSpot) use ($userId) {
+            $nicheSpot->is_visited = $nicheSpot->stamps()->where('user_id', $userId)->exists();
+            return $nicheSpot;
+        });
     }
-    
 }

--- a/src/app/Repositories/NicheSpot/NicheSpotRepositoryInterface.php
+++ b/src/app/Repositories/NicheSpot/NicheSpotRepositoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories\NicheSpot;
+
+use Illuminate\Database\Eloquent\Collection;
+
+interface NicheSpotRepositoryInterface
+{
+    /**
+     * ニッチスポット一覧取得
+     * 
+     * @return Collection
+     */
+    public function getNicheSpot(int $userId): Collection;
+}

--- a/src/app/Repositories/NicheSpot/NicheSpotRepositoryInterface.php
+++ b/src/app/Repositories/NicheSpot/NicheSpotRepositoryInterface.php
@@ -13,5 +13,5 @@ interface NicheSpotRepositoryInterface
      * 
      * @return Collection
      */
-    public function getNicheSpot(int $userId): Collection;
+    public function getNicheSpot(int $userId, $keyword): Collection;
 }

--- a/src/app/Services/NicheSpotService.php
+++ b/src/app/Services/NicheSpotService.php
@@ -61,7 +61,7 @@ class NicheSpotService
                 throw new UnauthorizedException();
             }
             // ニッチスポット一覧取得
-            $nicheSpots = $this->nicheSpotRepository->getNicheSpot($user[User::ID]);
+            $nicheSpots = $this->nicheSpotRepository->getNicheSpot($user[User::ID], $request[NicheSpot::KEYWORD]);
             // レスポンスデータの作成
             foreach($nicheSpots as $nicheSpot){
                 $responseData[NicheSpot::NICHE_SPOTS][] = [

--- a/src/app/Services/NicheSpotService.php
+++ b/src/app/Services/NicheSpotService.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Exceptions\UnauthorizedException;
+use App\Models\NicheSpot;
+use App\Models\User;
+use App\Repositories\NicheSpot\NicheSpotRepository;
+use App\Repositories\User\UserRepository;
+use App\Traits\DecodeJwt;
+use App\Traits\ExceptionHandlerTrait;
+use App\Traits\ResponseTrait;
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class NicheSpotService
+{
+    use ExceptionHandlerTrait;
+    use ResponseTrait;
+    use DecodeJwt;
+
+    /**
+     * NicheSpotService コンストラクタ
+     * UserRepository の依存性を注入する
+     * NicheSpotRepository の依存性を注入する
+     *
+     * @param UserRepository $userRepository
+     * @param NicheSpotRepository $nicheSpotRepository
+     */
+    public function __construct(
+        protected UserRepository $userRepository,
+        protected NicheSpotRepository $nicheSpotRepository
+    ) {}
+
+    /**
+     * ニッチスポット一覧取得
+     * 
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function getNicheSpot(Request $request): JsonResponse
+    {
+        $responseData = [];
+        try {
+            if (!$request->header('Authorization')) {
+                // token が存在しない場合
+                throw new UnauthorizedException();
+            }
+            // Header の Authorization から token を取得
+            $jwt = $request->header('Authorization');
+            // token をデコード
+            $decodedJwt = $this->decodeJWT($jwt);
+            // uid に紐づくユーザーの取得
+            $user = $this->userRepository->getUesr($decodedJwt['payload']['user_id']);
+            if (!$user) {
+                // uid に紐づく情報が存在しない場合
+                throw new UnauthorizedException();
+            }
+            // ニッチスポット一覧取得
+            $nicheSpots = $this->nicheSpotRepository->getNicheSpot($user[User::ID]);
+            // レスポンスデータの作成
+            foreach($nicheSpots as $nicheSpot){
+                $responseData[NicheSpot::NICHE_SPOTS][] = [
+                    NicheSpot::ID => $nicheSpot[NicheSpot::ID],
+                    NicheSpot::NAME => $nicheSpot[NicheSpot::NAME],
+                    NicheSpot::LATITUDE => $nicheSpot[NicheSpot::LATITUDE],
+                    NicheSpot::LONGITUDE => $nicheSpot[NicheSpot::LONGITUDE],
+                    NicheSpot::ADDRESS => $nicheSpot[NicheSpot::ADDRESS],
+                    NicheSpot::NUMBER_OF_VISITS => $nicheSpot[NicheSpot::STAMPS_COUNT],
+                    NicheSpot::IS_VISITED => $nicheSpot[NicheSpot::IS_VISITED]
+                ];
+            }
+        } catch (Exception $e) {
+            // エラーハンドリング
+            return $this->exceptionHandler($e);
+        }
+        // レスポンス
+        return $this->okResponse($responseData);
+    }
+}

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\AuthController;
+use App\Http\Controllers\NicheSpotController;
 use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
 
@@ -8,3 +9,4 @@ Route::put('user', UserController::class);
 Route::patch('login', [AuthController::class, 'login']);
 Route::get('me', [AuthController::class, 'me']);
 Route::delete('logout', [AuthController::class, 'logout']);
+Route::apiResource('niche_spot', NicheSpotController::class, ['only' => ['index', 'show']]);


### PR DESCRIPTION
## 実装内容
- ニッチスポット一覧取得処理の実装 [1612027e5542feb07a15e7c8de9bc4bc3aa7c917]
- レスポンスで使用する定数の実装 [181dfa1ba74714a95522ac83af9f0a69eaf06d16]
- ニッチスポット一覧取得処理の実装 [9466465c9525e85a24d836d9175eb6e8ef5bd5f8]
- ニッチスポット一覧取得処理を呼び出す処理の実装 [1a6e151a3bdfcf553d42055e201bf4a3d3976e67]
- api route 設定処理の実装 [21ac33224be153dd90a62e7b8f3c3bb7abf41b1f]
- リクエスト用定数の追加 [eb969bc4a046871c2f42c24411b21c37690d0a1f]
- キーワード検索処理の実装 [007b28651dbb3d164e04de59f55a02151102c31a]
- 引数の修正 [5aecc3098818fc36797c141352da8583474062df]