### PR TITLE
Feature/#create_nichespot_get_detail_api

### DIFF
--- a/src/app/Http/Controllers/NicheSpotController.php
+++ b/src/app/Http/Controllers/NicheSpotController.php
@@ -28,10 +28,13 @@ class NicheSpotController extends Controller
     }
 
     /**
-     * Store a newly created resource in storage.
+     * ニッチスポット詳細取得API
+     * 
+     * @param Request $request
+     * @return JsonResponse
      */
-    public function store(Request $request)
+    public function show(Request $request, int $id) : JsonResponse
     {
-        //
+        return $this->nicheSpotService->getDetailNicheSpot($request, $id);
     }
 }

--- a/src/app/Models/NicheSpot.php
+++ b/src/app/Models/NicheSpot.php
@@ -48,6 +48,7 @@ class NicheSpot extends Model
     const NUMBER_OF_VISITS = 'number_of_visits';
     const IS_VISITED = 'is_visited';
     const STAMPS_COUNT = 'stamps_count';
+    const IMAGE_LIST = 'image_list';
 
     public function stamps()
     {

--- a/src/app/Models/NicheSpotImage.php
+++ b/src/app/Models/NicheSpotImage.php
@@ -10,7 +10,7 @@ class NicheSpotImage extends Model
     use SoftDeletes;
 
     // テーブル名
-    const TABLE = 'favorite';
+    const TABLE = 'niche_spot_image';
     public $table = self::TABLE;
 
     // カラム名
@@ -29,4 +29,8 @@ class NicheSpotImage extends Model
         self::UPDATED_AT,
         self::DELETED_AT,
     ];
+
+    // レスポンス用カラム
+    const IMAGE_ID = 'image_id';
+
 }

--- a/src/app/Providers/AppServiceProvider.php
+++ b/src/app/Providers/AppServiceProvider.php
@@ -31,5 +31,9 @@ class AppServiceProvider extends ServiceProvider
             \App\Repositories\NicheSpotImage\NicheSpotImageRepositoryInterface::class,
             \App\Repositories\NicheSpotImage\NicheSpotImageRepository::class,
         );
+        $this->app->bind(
+            \App\Repositories\Stamp\StampRepositoryInterface::class,
+            \App\Repositories\Stamp\StampRepository::class,
+        );
     }
 }

--- a/src/app/Providers/AppServiceProvider.php
+++ b/src/app/Providers/AppServiceProvider.php
@@ -27,5 +27,9 @@ class AppServiceProvider extends ServiceProvider
             \App\Repositories\NicheSpot\NicheSpotRepositoryInterface::class,
             \App\Repositories\NicheSpot\NicheSpotRepository::class,
         );
+        $this->app->bind(
+            \App\Repositories\NicheSpotImage\NicheSpotImageRepositoryInterface::class,
+            \App\Repositories\NicheSpotImage\NicheSpotImageRepository::class,
+        );
     }
 }

--- a/src/app/Repositories/NicheSpot/NicheSpotRepository.php
+++ b/src/app/Repositories/NicheSpot/NicheSpotRepository.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace App\Repositories\NicheSpot;
 
 use App\Models\NicheSpot;
-use App\Models\Stamp;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Support\Facades\DB;
 
 class NicheSpotRepository implements NicheSpotRepositoryInterface
 {
@@ -42,5 +40,16 @@ class NicheSpotRepository implements NicheSpotRepositoryInterface
             $nicheSpot->is_visited = $nicheSpot->stamps()->where('user_id', $userId)->exists();
             return $nicheSpot;
         });
+    }
+
+    /**
+     * ニッチスポット詳細取得
+     * 
+     * @param $id
+     * @return object|null
+     */
+    public function getDetailNicheSpot($id) : object|null
+    {
+        return $this->nicheSpot->find($id);
     }
 }

--- a/src/app/Repositories/NicheSpot/NicheSpotRepositoryInterface.php
+++ b/src/app/Repositories/NicheSpot/NicheSpotRepositoryInterface.php
@@ -14,4 +14,12 @@ interface NicheSpotRepositoryInterface
      * @return Collection
      */
     public function getNicheSpot(int $userId, $keyword): Collection;
+
+    /**
+     * ニッチスポット詳細取得
+     * 
+     * @param $id
+     * @return object|null
+     */
+    public function getDetailNicheSpot($id): object|null;
 }

--- a/src/app/Repositories/NicheSpotImage/NicheSpotImageRepository.php
+++ b/src/app/Repositories/NicheSpotImage/NicheSpotImageRepository.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories\NicheSpotImage;
+
+use App\Models\NicheSpotImage;
+use Illuminate\Database\Eloquent\Collection;
+
+class NicheSpotImageRepository implements NicheSpotImageRepositoryInterface
+{
+
+    /**
+     * NicheSpotRepository コンストラクタ
+     * NicheSpot の依存性を注入する
+     * 
+     * @param NicheSpotImage $nicheSpotImage
+     */
+    public function __construct(protected NicheSpotImage $nicheSpotImage) {}
+
+    /**
+     * ニッチスポット画像一覧取得
+     * 
+     * @return Collection
+     */
+    public function getNicheSpotImages($nicheSpotId): Collection 
+    {
+        return $this->nicheSpotImage->where(NicheSpotImage::NICHE_SPOT_ID, $nicheSpotId)->get();
+    }
+}

--- a/src/app/Repositories/NicheSpotImage/NicheSpotImageRepositoryInterface.php
+++ b/src/app/Repositories/NicheSpotImage/NicheSpotImageRepositoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories\NicheSpotImage;
+
+use Illuminate\Database\Eloquent\Collection;
+
+interface NicheSpotImageRepositoryInterface
+{
+    /**
+     * ニッチスポット画像一覧取得
+     * 
+     * @return Collection
+     */
+    public function getNicheSpotImages($nicheSpotId): Collection;
+}

--- a/src/app/Repositories/Stamp/StampRepository.php
+++ b/src/app/Repositories/Stamp/StampRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories\Stamp;
+
+use App\Models\Stamp;
+use Illuminate\Database\Eloquent\Collection;
+
+class StampRepository implements StampRepositoryInterface
+{
+
+    /**
+     * NicheSpotRepository コンストラクタ
+     * NicheSpot の依存性を注入する
+     * 
+     * @param Stamp $nicheSpot
+     */
+    public function __construct(protected Stamp $stamp) {}
+
+    /**
+     * スタンプ数取得
+     */
+    public function getCountStamp($nicheSpotId): int
+    {
+        return $this->stamp->where(Stamp::NICHE_SPOT_ID, $nicheSpotId)->count();
+    }
+}

--- a/src/app/Repositories/Stamp/StampRepositoryInterface.php
+++ b/src/app/Repositories/Stamp/StampRepositoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repositories\Stamp;
+
+interface StampRepositoryInterface
+{
+    /**
+     * スタンプ数取得
+     */
+    public function getCountStamp($nicheSpotId): int;
+}

--- a/src/app/Services/NicheSpotService.php
+++ b/src/app/Services/NicheSpotService.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Exceptions\NotFoundException;
 use App\Exceptions\UnauthorizedException;
 use App\Models\NicheSpot;
+use App\Models\NicheSpotImage;
+use App\Models\Stamp;
 use App\Models\User;
 use App\Repositories\NicheSpot\NicheSpotRepository;
+use App\Repositories\NicheSpotImage\NicheSpotImageRepository;
+use App\Repositories\Stamp\StampRepository;
 use App\Repositories\User\UserRepository;
 use App\Traits\DecodeJwt;
 use App\Traits\ExceptionHandlerTrait;
@@ -33,7 +38,9 @@ class NicheSpotService
      */
     public function __construct(
         protected UserRepository $userRepository,
-        protected NicheSpotRepository $nicheSpotRepository
+        protected NicheSpotRepository $nicheSpotRepository,
+        protected NicheSpotImageRepository $nicheSpotImageRepository,
+        protected StampRepository $stampRepository
     ) {}
 
     /**
@@ -63,7 +70,7 @@ class NicheSpotService
             // ニッチスポット一覧取得
             $nicheSpots = $this->nicheSpotRepository->getNicheSpot($user[User::ID], $request[NicheSpot::KEYWORD]);
             // レスポンスデータの作成
-            foreach($nicheSpots as $nicheSpot){
+            foreach ($nicheSpots as $nicheSpot) {
                 $responseData[NicheSpot::NICHE_SPOTS][] = [
                     NicheSpot::ID => $nicheSpot[NicheSpot::ID],
                     NicheSpot::NAME => $nicheSpot[NicheSpot::NAME],
@@ -74,6 +81,46 @@ class NicheSpotService
                     NicheSpot::IS_VISITED => $nicheSpot[NicheSpot::IS_VISITED]
                 ];
             }
+        } catch (Exception $e) {
+            // エラーハンドリング
+            return $this->exceptionHandler($e);
+        }
+        // レスポンス
+        return $this->okResponse($responseData);
+    }
+
+    /**
+     * ニッチスポット詳細取得
+     * 
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function getDetailNicheSpot(Request $request, int $id): JsonResponse
+    {
+        $responseData = [];
+        $images = [];
+        try {
+            // ニッチスポット一覧取得
+            $nicheSpot = $this->nicheSpotRepository->getDetailNicheSpot($id);
+            if(!$nicheSpot) {
+                throw new NotFoundException();
+            }
+            $nicheSpotImages = $this->nicheSpotImageRepository->getNicheSpotImages($id);
+            foreach ($nicheSpotImages as $nicheSpotImage) {
+                $images[] = [
+                    NicheSpotImage::IMAGE_ID => $nicheSpotImage[NicheSpotImage::ID],
+                    NicheSpotImage::IMAGE_PATH => config('app.url') . '/storage/' . $nicheSpotImage[NicheSpotImage::IMAGE_PATH]
+                ];
+            }
+            // レスポンスデータの作成
+            $responseData = [
+                NicheSpot::ID => $nicheSpot[NicheSpot::ID],
+                NicheSpot::NAME => $nicheSpot[NicheSpot::NAME],
+                NicheSpot::ADDRESS => $nicheSpot[NicheSpot::ADDRESS],
+                NicheSpot::NUMBER_OF_VISITS => $this->stampRepository->getCountStamp($id),
+                NicheSpot::IMAGE_LIST => $images,
+                NicheSpot::COMMENT => $nicheSpot[NicheSpot::COMMENT]
+            ];
         } catch (Exception $e) {
             // エラーハンドリング
             return $this->exceptionHandler($e);


### PR DESCRIPTION
## 修正内容
- バインド処理の実装 [986c29245b70395432f02f9b98dc3987b3717ca1]
- 定数の実装 [32e2af9fce313599ce1e5aca07f8519e7f611aa2]
- モデルクラスの修正 [a31528434385ee026e778007e2a0f97bf20ad308]
- ニッチスポット詳細取得処理の実装 [de86312c138e921deb987f05d8227901e8c843cd]
- ニッチスポット画像一覧取得処理の実装 [ca56ce13d80cb4f10587864526fbfe51e4232d9f]
- スタンプ数取得処理の実装 [953d481a1f0594403764fb9595943ff93c36f81d]
- バインド処理の実装 [b263548dd8fe149e37986bb6ee0a71bbd12e3ca]
- ニッチスポット詳細取得処理の実装 [8f5e1788bef0f5722f15ad29941ba174f4bf056e]
- ニッチ詳細取得処理を呼び出す処理の実装 [f827a0b2dcba06a4cd579f643a8f930ea9fa6ac4]